### PR TITLE
resource-limitations: Custom minimum/maximum for connection arguments

### DIFF
--- a/.changeset/tame-rules-stare.md
+++ b/.changeset/tame-rules-stare.md
@@ -1,0 +1,5 @@
+---
+'@envelop/resource-limitations': minor
+---
+
+Allow using custom minimum/maximum for connection arguments

--- a/packages/plugins/resource-limitations/README.md
+++ b/packages/plugins/resource-limitations/README.md
@@ -18,8 +18,10 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useResourceLimitations({
-      paginationArgumentScalars: ['ConnectionInt'], // optional, use if connections use a different scalar type as the argument instead of `Int`
       nodeCostLimit: 500000, // optional, default to 500000
+      paginationArgumentMaximum: 100, // optional, default to 100
+      paginationArgumentMinimum: 1, // optional, default to 1
+      paginationArgumentScalars: ['ConnectionInt'], // optional, use if connections use a different scalar type as the argument instead of `Int`
       extensions: false, // set this to `true` in order to add the calculated const to the response of queries
     }),
   ],

--- a/packages/plugins/resource-limitations/test/use-resource-limitations.spec.ts
+++ b/packages/plugins/resource-limitations/test/use-resource-limitations.spec.ts
@@ -99,7 +99,7 @@ describe('useResourceLimitations', () => {
       "Missing pagination argument for field 'repositories'. Please provide either the 'first' or 'last' field argument."
     );
   });
-  it('requires the first field to be within the be at least 1', async () => {
+  it('requires the first field to be at least 1', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
     const result = await testkit.execute(/* GraphQL */ `
       query {
@@ -121,7 +121,29 @@ describe('useResourceLimitations', () => {
       "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 1-100."
     );
   });
-  it('requires the first field to be within the be not higher than 100', async () => {
+  it('requires the first field to be at least a custom minimum value', async () => {
+    const testkit = createTestkit([useResourceLimitations({ paginationArgumentMinimum: 2, extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(first: 1) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toEqual(1);
+    expect(result.errors?.[0]?.message).toEqual(
+      "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 2-100."
+    );
+  });
+  it('requires the first field to be not higher than 100', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
     const result = await testkit.execute(/* GraphQL */ `
       query {
@@ -143,7 +165,29 @@ describe('useResourceLimitations', () => {
       "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 1-100."
     );
   });
-  it('requires the last field to be within the be at least 1', async () => {
+  it('requires the first field to be not higher than a custom maximum value', async () => {
+    const testkit = createTestkit([useResourceLimitations({ paginationArgumentMaximum: 99, extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(first: 100) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toEqual(1);
+    expect(result.errors?.[0]?.message).toEqual(
+      "Invalid pagination argument for field repositories. The value for the 'first' argument must be an integer within 1-99."
+    );
+  });
+  it('requires the last field to be at least 1', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
     const result = await testkit.execute(/* GraphQL */ `
       query {
@@ -165,7 +209,29 @@ describe('useResourceLimitations', () => {
       "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 1-100."
     );
   });
-  it('requires the last field to be within the be not higher than 100', async () => {
+  it('requires the last field to be at least a custom minimum value', async () => {
+    const testkit = createTestkit([useResourceLimitations({ paginationArgumentMinimum: 2, extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(last: 1) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toEqual(1);
+    expect(result.errors?.[0]?.message).toEqual(
+      "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 2-100."
+    );
+  });
+  it('requires the last field to be not higher than 100', async () => {
     const testkit = createTestkit([useResourceLimitations({ extensions: true })], schema);
     const result = await testkit.execute(/* GraphQL */ `
       query {
@@ -185,6 +251,28 @@ describe('useResourceLimitations', () => {
     expect(result.errors?.length).toEqual(1);
     expect(result.errors?.[0]?.message).toEqual(
       "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 1-100."
+    );
+  });
+  it('requires the last field to be not higher than a custom maximum value', async () => {
+    const testkit = createTestkit([useResourceLimitations({ paginationArgumentMaximum: 99, extensions: true })], schema);
+    const result = await testkit.execute(/* GraphQL */ `
+      query {
+        viewer {
+          repositories(last: 100) {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    assertSingleExecutionValue(result);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toEqual(1);
+    expect(result.errors?.[0]?.message).toEqual(
+      "Invalid pagination argument for field repositories. The value for the 'last' argument must be an integer within 1-99."
     );
   });
   it('calculates node cost (single)', async () => {


### PR DESCRIPTION
## Description

Add options for customizing the min/max of the `first` and `last` arguments in the connection types.

Fixes #816

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] unit tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
