### PR TITLE
resource-limitations: Custom types for connection arguments

### DIFF
--- a/.changeset/sharp-ravens-double.md
+++ b/.changeset/sharp-ravens-double.md
@@ -1,0 +1,5 @@
+---
+'@envelop/resource-limitations': minor
+---
+
+resource-limitations: Custom types for connection arguments

--- a/.changeset/sharp-ravens-double.md
+++ b/.changeset/sharp-ravens-double.md
@@ -2,4 +2,4 @@
 '@envelop/resource-limitations': minor
 ---
 
-resource-limitations: Custom types for connection arguments
+Allow using custom scalars for connection arguments.

--- a/packages/plugins/resource-limitations/README.md
+++ b/packages/plugins/resource-limitations/README.md
@@ -18,7 +18,7 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useResourceLimitations({
-      argumentTypes: ['ConnectionInt'], // optional, use if connections use a different scalar type than `Int`
+      paginationArgumentScalars: ['ConnectionInt'], // optional, use if connections use a different scalar type as the argument instead of `Int`
       nodeCostLimit: 500000, // optional, default to 500000
       extensions: false, // set this to `true` in order to add the calculated const to the response of queries
     }),

--- a/packages/plugins/resource-limitations/README.md
+++ b/packages/plugins/resource-limitations/README.md
@@ -18,6 +18,7 @@ const getEnveloped = envelop({
   plugins: [
     // ... other plugins ...
     useResourceLimitations({
+      argumentTypes: ['ConnectionInt'], // optional, use if connections use a different scalar type than `Int`
       nodeCostLimit: 500000, // optional, default to 500000
       extensions: false, // set this to `true` in order to add the calculated const to the response of queries
     }),

--- a/packages/plugins/resource-limitations/src/index.ts
+++ b/packages/plugins/resource-limitations/src/index.ts
@@ -23,8 +23,8 @@ const getWrappedType = (graphqlType: GraphQLType): Exclude<GraphQLType, GraphQLL
   return graphqlType;
 };
 
-const isValidArgType = (type: GraphQLInputType, argumentTypes?: string[]): boolean =>
-  type === GraphQLInt || (isScalarType(type) && !!argumentTypes && argumentTypes.includes(type.name));
+const isValidArgType = (type: GraphQLInputType, paginationArgumentTypes?: string[]): boolean =>
+  type === GraphQLInt || (isScalarType(type) && !!paginationArgumentTypes && paginationArgumentTypes.includes(type.name));
 
 const hasFieldDefConnectionArgs = (field: GraphQLField<any, any>, argumentTypes?: string[]) => {
   let hasFirst = false;
@@ -54,7 +54,7 @@ const buildInvalidPaginationRangeErrorMessage = (params: { fieldName: string; ar
 export const defaultNodeCostLimit = 500000;
 
 export type ResourceLimitationValidationRuleParams = {
-  argumentTypes?: string[];
+  paginationArgumentTypes?: string[];
   nodeCostLimit: number;
   reportNodeCost?: (cost: number, executionArgs: ExecutionArgs) => void;
 };
@@ -83,7 +83,7 @@ export const ResourceLimitationValidationRule =
               let nodeCost = 1;
               connectionFieldMap.add(fieldNode);
 
-              const { hasFirst, hasLast } = hasFieldDefConnectionArgs(fieldDef, params.argumentTypes);
+              const { hasFirst, hasLast } = hasFieldDefConnectionArgs(fieldDef, params.paginationArgumentTypes);
               if (hasFirst === false && hasLast === false) {
                 // eslint-disable-next-line no-console
                 console.warn('Encountered paginated field without pagination arguments.');
@@ -179,7 +179,7 @@ type UseResourceLimitationsParams = {
   /**
    * The custom scalar types accepted for connection arguments.
    */
-  argumentTypes?: string[];
+  paginationArgumentScalars?: string[];
   /**
    * The node cost limit for rejecting a operation.
    * @default 500000
@@ -215,7 +215,7 @@ export const useResourceLimitations = (params?: UseResourceLimitationsParams): P
         useExtendedValidation({
           rules: [
             ResourceLimitationValidationRule({
-              argumentTypes: params?.argumentTypes,
+              paginationArgumentTypes: params?.paginationArgumentScalars,
               nodeCostLimit,
               reportNodeCost: extensions
                 ? (nodeCost, ref) => {

--- a/packages/plugins/resource-limitations/test/use-resource-limitations.spec.ts
+++ b/packages/plugins/resource-limitations/test/use-resource-limitations.spec.ts
@@ -211,7 +211,10 @@ describe('useResourceLimitations', () => {
     });
   });
   it('calculates node cost on connections with custom argument types (single)', async () => {
-    const testkit = createTestkit([useResourceLimitations({ argumentTypes: ['ConnectionInt'], extensions: true })], schema);
+    const testkit = createTestkit(
+      [useResourceLimitations({ paginationArgumentScalars: ['ConnectionInt'], extensions: true })],
+      schema
+    );
     const result = await testkit.execute(/* GraphQL */ `
       query {
         viewer {


### PR DESCRIPTION
## Description

An option is accepted by the plugin to customize the type of the connection arguments.

Fixes #815

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] unit test

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
