### PR TITLE
feat: allow async onExecuteDone hook

### DIFF
--- a/.changeset/seven-bugs-sip.md
+++ b/.changeset/seven-bugs-sip.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': minor
+'@envelop/types': minor
+---
+
+Allow async OnExecuteDone hook

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -467,7 +467,7 @@ export function createEnvelopOrchestrator<PluginsContext extends DefaultContext>
         const onEndHandler: OnExecuteDoneHookResultOnEndHook[] = [];
 
         for (const afterCb of afterCalls) {
-          const hookResult = afterCb({
+          const hookResult = await afterCb({
             args: args as TypedExecutionArgs<PluginsContext>,
             result,
             setResult: newResult => {

--- a/packages/core/test/execute.spec.ts
+++ b/packages/core/test/execute.spec.ts
@@ -269,4 +269,26 @@ describe('execute', () => {
     await instance.next();
     await instance.return!();
   });
+
+  it('should allow to use an async function for the done hook', async () => {
+    const executeMock = jest.fn();
+    const testkit = createTestkit(
+      [
+        {
+          onExecute({ setExecuteFn }) {
+            setExecuteFn(executeMock as any);
+
+            return {
+              onExecuteDone: async ({ setResult }) => {
+                setResult({ data: { test: await Promise.resolve('test') } });
+              },
+            };
+          },
+        },
+      ],
+      schema
+    );
+
+    expect(await testkit.execute(query)).toEqual({ data: { test: 'test' } });
+  });
 });

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -392,7 +392,7 @@ export type OnExecuteDoneEventPayload<ContextType> = {
  */
 export type OnExecuteDoneHook<ContextType> = (
   options: OnExecuteDoneEventPayload<ContextType>
-) => void | OnExecuteDoneHookResult<ContextType>;
+) => PromiseOrValue<void | OnExecuteDoneHookResult<ContextType>>;
 
 /**
  * Result returned from the onExecute hook result for hooking into subsequent phases.


### PR DESCRIPTION
## Description

Allow async function for the onExecuteDoneHook.

One exemple of use case is to allow wraping every execution into a database transaction with automatic commit/rollback as shown in the linked issue.

Fixes #868

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Example of plugin using this feature :

```ts
export function useTransactions(options): TransactionsPlugin {
  return {
    async onExecute({ args: { contextValue } }) {
      const operationType = getOperationType(contextValue)
      if(operationType != 'query' && operationType != 'mutation') return
      
	  const transaction = await options.newTransaction(operationType === 'query' ? 'read-only' : 'auto')
      
      return {
        async onExecuteDone({result}) {
          try {
          	if(isAsyncIterable(result)) throw TypeError('Async Iterable results are not implemented')
            if(result.errors) throw result.errors
            await transaction.commit()
          } catch (err) {
            await transaction.rollback(err)
          } finally {
            await transaction.releaseClient()
          }
        }
      }
    }
  }
}
```

## How Has This Been Tested?

- [x] Unit test which tests that it is possible to return a Promise from an OnExexcuteDoneHook


**Test Environment**:

- OS: macOs
- `@envelop/core`: 1.3.0
- NodeJS: v16.11.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

