### PR TITLE
Avoid nested imports from graphql-js

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         graphql_version:
-          # - 14
+          - 14
           - 15
           - 16.0.0-rc.6
     steps:
@@ -65,7 +65,7 @@ jobs:
         os: [ubuntu-latest] # remove windows to speed up the tests
         node-version: [12, '16']
         graphql_version:
-          # - 14
+          - 14
           - 15
           - 16.0.0-rc.6
     steps:

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -26,6 +26,7 @@ import {
   OnContextErrorHandler,
   SubscribeErrorHook,
   DefaultContext,
+  Maybe,
 } from '@envelop/types';
 import {
   DocumentNode,
@@ -39,7 +40,6 @@ import {
   validate,
   ValidationRule,
 } from 'graphql';
-import { Maybe } from 'graphql/jsutils/Maybe';
 import { prepareTracedSchema, resolversHooksSymbol } from './traced-schema';
 import { errorAsyncIterator, finalAsyncIterator, makeExecute, makeSubscribe, mapAsyncIterator } from './utils';
 

--- a/packages/core/src/traced-orchestrator.ts
+++ b/packages/core/src/traced-orchestrator.ts
@@ -1,6 +1,5 @@
 import { DocumentNode, ExecutionArgs, GraphQLFieldResolver, GraphQLSchema, GraphQLTypeResolver, SubscriptionArgs } from 'graphql';
-import { Maybe } from 'graphql/jsutils/Maybe';
-import { ArbitraryObject, isAsyncIterable } from '@envelop/types';
+import { ArbitraryObject, isAsyncIterable, Maybe } from '@envelop/types';
 import { EnvelopOrchestrator } from './orchestrator';
 
 const HR_TO_NS = 1e9;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -16,8 +16,8 @@ import {
   PolymorphicExecuteArguments,
   PolymorphicSubscribeArguments,
   SubscribeFunction,
+  PromiseOrValue,
 } from '@envelop/types';
-import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
 
 export const envelopIsIntrospectionSymbol = Symbol('ENVELOP_IS_INTROSPECTION');
 

--- a/packages/plugins/execute-subscription-event/src/index.ts
+++ b/packages/plugins/execute-subscription-event/src/index.ts
@@ -1,7 +1,6 @@
 import { SubscriptionArgs, execute } from 'graphql';
-import { Plugin } from '@envelop/types';
+import { Plugin, PromiseOrValue } from '@envelop/types';
 import { makeExecute, DefaultContext } from '@envelop/core';
-import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
 import { subscribe } from './subscribe';
 
 export type ContextFactoryOptions = {

--- a/packages/plugins/execute-subscription-event/src/subscribe.ts
+++ b/packages/plugins/execute-subscription-event/src/subscribe.ts
@@ -31,7 +31,7 @@ export const subscribe = (execute: ExecuteFunction): SubscribeFunction =>
     // the GraphQL specification. The `execute` function provides the
     // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
     // "ExecuteQuery" algorithm, for which `execute` is also used.
-    const mapSourceToResponse = async (payload: unknown) =>
+    const mapSourceToResponse = (payload: object) =>
       execute({
         schema,
         document,

--- a/packages/plugins/extended-validation/package.json
+++ b/packages/plugins/extended-validation/package.json
@@ -29,7 +29,9 @@
     "test": "jest",
     "prepack": "bob prepack"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@graphql-tools/utils": "8.5.0"
+  },
   "devDependencies": {
     "bob-the-bundler": "1.5.1", "graphql": "15.6.1",
   "typescript": "4.4.4"

--- a/packages/plugins/extended-validation/src/rules/one-of.ts
+++ b/packages/plugins/extended-validation/src/rules/one-of.ts
@@ -1,5 +1,5 @@
 import { ArgumentNode, GraphQLError, GraphQLInputObjectType, GraphQLInputType, isListType, ValidationContext } from 'graphql';
-import { getArgumentValues } from 'graphql/execution/values.js';
+import { getArgumentValues } from '@graphql-tools/utils';
 import { ExtendedValidationRule, getDirectiveFromAstNode, unwrapType } from '../common';
 
 export const ONE_OF_DIRECTIVE_SDL = /* GraphQL */ `
@@ -18,7 +18,7 @@ export const OneOfInputObjectsRule: ExtendedValidationRule = (validationContext,
           return;
         }
 
-        const values = getArgumentValues(fieldType, node, executionArgs.variableValues);
+        const values = getArgumentValues(fieldType, node, executionArgs.variableValues || undefined);
 
         if (fieldType) {
           const isOneOfFieldType =

--- a/packages/plugins/fragment-arguments/src/index.ts
+++ b/packages/plugins/fragment-arguments/src/index.ts
@@ -1,6 +1,6 @@
-import { Plugin } from '@envelop/types';
-import { ParseOptions } from 'graphql/language/parser';
-import { Source, DocumentNode } from 'graphql';
+import type { Plugin } from '@envelop/types';
+import type { ParseOptions } from 'graphql/language/parser';
+import type { Source, DocumentNode } from 'graphql';
 import { FragmentArgumentCompatibleParser } from './extended-parser';
 import { applySelectionSetFragmentArguments } from './utils';
 

--- a/packages/plugins/newrelic/src/index.ts
+++ b/packages/plugins/newrelic/src/index.ts
@@ -1,7 +1,6 @@
 import newRelic from 'newrelic';
-import { Plugin, OnResolverCalledHook, isAsyncIterable } from '@envelop/types';
+import { Plugin, OnResolverCalledHook, isAsyncIterable, Path } from '@envelop/types';
 import { print, FieldNode, Kind, OperationDefinitionNode } from 'graphql';
-import { Path } from 'graphql/jsutils/Path';
 
 const { shim: instrumentationApi } = newRelic;
 

--- a/packages/plugins/resource-limitations/package.json
+++ b/packages/plugins/resource-limitations/package.json
@@ -30,7 +30,9 @@
     "test": "jest",
     "prepack": "bob prepack"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@graphql-tools/utils": "8.5.0"
+  },
   "devDependencies": {
     "bob-the-bundler": "1.5.1", "graphql": "15.6.1",
   "typescript": "4.4.4"

--- a/packages/plugins/resource-limitations/src/index.ts
+++ b/packages/plugins/resource-limitations/src/index.ts
@@ -14,7 +14,7 @@ import {
   GraphQLType,
   isScalarType,
 } from 'graphql';
-import { getArgumentValues } from 'graphql/execution/values.js';
+import { getArgumentValues } from '@graphql-tools/utils';
 
 const getWrappedType = (graphqlType: GraphQLType): Exclude<GraphQLType, GraphQLList<any> | GraphQLNonNull<any>> => {
   if (graphqlType instanceof GraphQLList || graphqlType instanceof GraphQLNonNull) {
@@ -89,7 +89,7 @@ export const ResourceLimitationValidationRule =
 
             // if it is not found the query is invalid and graphql validation will complain
             if (fieldDef != null) {
-              const argumentValues = getArgumentValues(fieldDef, fieldNode, executionArgs.variableValues);
+              const argumentValues = getArgumentValues(fieldDef, fieldNode, executionArgs.variableValues || undefined);
               const type = getWrappedType(fieldDef.type);
               if (type instanceof GraphQLObjectType && type.name.endsWith('Connection')) {
                 let nodeCost = 1;

--- a/packages/types/src/async-utils.ts
+++ b/packages/types/src/async-utils.ts
@@ -13,7 +13,11 @@ import {
  * Source: https://github.com/graphql/graphql-js/blob/main/src/jsutils/isAsyncIterable.ts
  */
 export function isAsyncIterable<T = any>(maybeAsyncIterable: any): maybeAsyncIterable is AsyncIterable<T> {
-  return typeof maybeAsyncIterable?.[Symbol.asyncIterator] === 'function';
+  return (
+    maybeAsyncIterable != null &&
+    typeof maybeAsyncIterable === 'object' &&
+    typeof maybeAsyncIterable[Symbol.asyncIterator] === 'function'
+  );
 }
 
 /**

--- a/packages/types/src/get-enveloped.ts
+++ b/packages/types/src/get-enveloped.ts
@@ -1,8 +1,7 @@
 import { Plugin } from './plugin';
 import { GraphQLSchema } from 'graphql';
-import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
 import { ExecuteFunction, ParseFunction, SubscribeFunction, ValidateFunction } from './graphql';
-import { ArbitraryObject, Spread } from './utils';
+import { ArbitraryObject, Spread, PromiseOrValue } from './utils';
 export { ArbitraryObject } from './utils';
 
 export type EnvelopContextFnWrapper<TFunction extends Function, ContextType = unknown> = (context: ContextType) => TFunction;

--- a/packages/types/src/graphql.ts
+++ b/packages/types/src/graphql.ts
@@ -9,6 +9,7 @@ import type {
   execute,
   parse,
   validate,
+  GraphQLResolveInfo,
 } from 'graphql';
 import type { Maybe } from './utils';
 
@@ -68,3 +69,5 @@ export type ValidateFunctionParameter = {
   typeInfo?: Parameters<ValidateFunction>[3];
   options?: Parameters<ValidateFunction>[4];
 };
+
+export type Path = GraphQLResolveInfo['path'];

--- a/packages/types/src/hooks.ts
+++ b/packages/types/src/hooks.ts
@@ -10,8 +10,7 @@ import type {
   SubscriptionArgs,
   ValidationRule,
 } from 'graphql';
-import { Maybe } from 'graphql/jsutils/Maybe';
-import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
+import { Maybe, PromiseOrValue } from './utils';
 import { DefaultContext } from './context-types';
 import { ExecuteFunction, ParseFunction, ValidateFunction, ValidateFunctionParameter } from '@envelop/core';
 import { SubscribeFunction } from './graphql';


### PR DESCRIPTION
Remove nested imports from `graphql-js` like `graphql/*` because the deeper exports are not the same in v16