### PR TITLE
Fix `skipError` function implementation by applying it to onExecuteDone

### DIFF
--- a/.changeset/brave-emus-marry.md
+++ b/.changeset/brave-emus-marry.md
@@ -1,0 +1,5 @@
+---
+'@envelop/newrelic': patch
+---
+
+Fix skipError function implementation by applying it to onExecuteDone

--- a/packages/plugins/newrelic/README.md
+++ b/packages/plugins/newrelic/README.md
@@ -44,6 +44,7 @@ const getEnveloped = envelop({
       trackResolvers: true, // default `false`. When set to `true`, track resolvers as segments to monitor their performance
       includeResolverArgs: false, // default `false`. When set to `true`, includes all the arguments passed to resolvers with their values
       rootFieldsNaming: true, // default `false`. When set to `true` append the names of operation root fields to the transaction name
+      skipError: error => { ... return true; }, // a function that allows you to skip reporting a given error to NewRelic. By default custom `EnvelopError`s will be skipped
       operationNameProperty: 'id', // default empty. When passed will check for the property name passed, within the document object. Will eventually use its value as operation name. Useful for custom document properties (e.g. queryId/hash)
     }),
   ],
@@ -62,9 +63,9 @@ Below is a quick example of how you can use RegEx to set up white/black listing 
 
 ```ts
 useNewRelic({
-  includeExecuteVariables: /^(client.*|application.*)$.*$/i, // whitelist, track only variables whose name starts with client or application (e.g. clientName, applicationId)
+  includeExecuteVariables: /client|application/i, // whitelist, track only variables whose name contains "client" or "application" (e.g. clientName, applicationId, xApplicationId)
   trackResolvers: true, // track resolvers, since we also want to track resolvers' arguments
-  includeResolverArgs: /^(?!(name|email|password)$).*$/, // blacklist, track all arguments whose name does not match 'name', 'email' nor 'password'
+  includeResolverArgs: /^(?!name|email|password).*/i, // blacklist, track all arguments whose name does not match 'name', 'email' nor 'password'
 }),
 ```
 


### PR DESCRIPTION
## Description

The NewRelic plugin has an implementation for a `skipError` function.
However, this function is currently invoked only in `onResolverCalled` when the resolver result is an error instance.

This means that it cannot be applied to all errors, also because the `onResolverCalled` hook is not even registered unless the consumer manually sets the `trackResolvers` option to true.

In this PR I want to change how `skipError` is used by moving it to `onExecuteDone` hook which will invoke this function on all errors available in the payload so that it can actually check against all errors available.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
~- [ ] Any dependent changes have been merged and published in downstream modules~