### PR TITLE
experiment: [plugin/sentry] Use OTEL plugin for Sentry

### DIFF
--- a/.changeset/@envelop_sentry-2334-dependencies.md
+++ b/.changeset/@envelop_sentry-2334-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@envelop/sentry": patch
+---
+dependencies updates:
+  - Added dependency [`@opentelemetry/api@^1.8.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/api/v/1.8.0) (to `dependencies`)
+  - Added dependency [`@opentelemetry/sdk-trace-base@^1.11.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/sdk-trace-base/v/1.11.0) (to `dependencies`)
+  - Added dependency [`@sentry/opentelemetry@^8.40.0` ↗︎](https://www.npmjs.com/package/@sentry/opentelemetry/v/8.40.0) (to `dependencies`)

--- a/.changeset/@envelop_sentry-2334-dependencies.md
+++ b/.changeset/@envelop_sentry-2334-dependencies.md
@@ -2,6 +2,7 @@
 "@envelop/sentry": patch
 ---
 dependencies updates:
+  - Added dependency [`@envelop/opentelemetry@workspace:^` ↗︎](https://www.npmjs.com/package/@envelop/opentelemetry/v/workspace:^) (to `dependencies`)
   - Added dependency [`@opentelemetry/api@^1.8.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/api/v/1.8.0) (to `dependencies`)
   - Added dependency [`@opentelemetry/sdk-trace-base@^1.11.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/sdk-trace-base/v/1.11.0) (to `dependencies`)
   - Added dependency [`@sentry/opentelemetry@^8.40.0` ↗︎](https://www.npmjs.com/package/@sentry/opentelemetry/v/8.40.0) (to `dependencies`)

--- a/.changeset/popular-bears-help.md
+++ b/.changeset/popular-bears-help.md
@@ -1,0 +1,5 @@
+---
+'@envelop/sentry': major
+---
+
+Use OpenTelemetry instead of Sentry SDK

--- a/packages/plugins/sentry/__tests__/sentry.spec.ts
+++ b/packages/plugins/sentry/__tests__/sentry.spec.ts
@@ -13,6 +13,7 @@ describe('sentry', () => {
     Sentry.init({
       dsn: 'https://public@sentry.example.com/1',
       transport: sentryTransport,
+      skipOpenTelemetrySetup: true,
     });
 
     const schema = makeExecutableSchema({

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -52,6 +52,9 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.8.0",
+    "@opentelemetry/sdk-trace-base": "^1.11.0",
+    "@sentry/opentelemetry": "^8.40.0",
     "tslib": "^2.5.0"
   },
   "devDependencies": {
@@ -59,7 +62,7 @@
     "@graphql-tools/schema": "10.0.8",
     "@sentry/node": "^8.22.0",
     "@sentry/tracing": "^7.114.0",
-    "@sentry/types": "^8.22.0",
+    "@sentry/types": "^8.32.0",
     "graphql": "16.8.1",
     "sentry-testkit": "5.0.9",
     "typescript": "5.1.3"

--- a/packages/plugins/sentry/package.json
+++ b/packages/plugins/sentry/package.json
@@ -52,6 +52,7 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
+    "@envelop/opentelemetry": "workspace:^",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.11.0",
     "@sentry/opentelemetry": "^8.40.0",

--- a/packages/plugins/sentry/src/index.ts
+++ b/packages/plugins/sentry/src/index.ts
@@ -1,277 +1,63 @@
-import { GraphQLError, Kind, OperationDefinitionNode, print } from 'graphql';
-import {
-  getDocumentString,
-  handleStreamOrSingleExecutionResult,
-  isOriginalGraphQLError,
-  OnExecuteDoneHookResultOnNextHook,
-  TypedExecutionArgs,
-  type Plugin,
-} from '@envelop/core';
+import { type Plugin } from '@envelop/core';
+import { useOpenTelemetry, type TracingOptions } from '@envelop/opentelemetry';
+import { Attributes, SpanKind, TracerProvider } from '@opentelemetry/api';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import * as Sentry from '@sentry/node';
-import type { Span, TraceparentData } from '@sentry/types';
+import { SentryPropagator, SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry';
+import type { Client } from '@sentry/types';
 
-export type SentryPluginOptions<PluginContext extends Record<string, any>> = {
-  /**
-   * Starts a new transaction for every GraphQL Operation.
-   * When disabled, an already existing Transaction will be used.
-   *
-   * @default true
-   */
-  startTransaction?: boolean;
-  /**
-   * Renames Transaction.
-   * @default false
-   */
-  renameTransaction?: boolean;
-  /**
-   * Adds result of each resolver and operation to Span's data (available under "result")
-   * @default false
-   */
-  includeRawResult?: boolean;
-  /**
-   * Adds operation's variables to a Scope (only in case of errors)
-   * @default false
-   */
-  includeExecuteVariables?: boolean;
-  /**
-   * The key of the event id in the error's extension. `null` to disable.
-   * @default sentryEventId
-   */
-  eventIdKey?: string | null;
-  /**
-   * Adds custom tags to every Transaction.
-   */
-  appendTags?: (args: TypedExecutionArgs<PluginContext>) => Record<string, unknown>;
-  /**
-   * Callback to set context information onto the scope.
-   */
-  configureScope?: (args: TypedExecutionArgs<PluginContext>, scope: Sentry.Scope) => void;
-  /**
-   * Produces a name of Transaction (only when "renameTransaction" or "startTransaction" are enabled) and description of created Span.
-   *
-   * @default operation's name or "Anonymous Operation" when missing)
-   */
-  transactionName?: (args: TypedExecutionArgs<PluginContext>) => string;
-  /**
-   * Produces tracing data for Transaction
-   *
-   * @default is empty
-   */
-  traceparentData?: (args: TypedExecutionArgs<PluginContext>) => TraceparentData | undefined;
-  /**
-   * Produces a "op" (operation) of created Span.
-   *
-   * @default execute
-   */
-  operationName?: (args: TypedExecutionArgs<PluginContext>) => string;
-  /**
-   * Indicates whether or not to skip the entire Sentry flow for given GraphQL operation.
-   * By default, no operations are skipped.
-   */
-  skip?: (args: TypedExecutionArgs<PluginContext>) => boolean;
-  /**
-   * Indicates whether or not to skip Sentry exception reporting for a given error.
-   * By default, this plugin skips all `GraphQLError` errors and does not report it to Sentry.
-   */
-  skipError?: (args: Error) => boolean;
+export type SentryPluginOptions = {
+  otel?: TracingOptions;
+  tracingProvider?: TracerProvider;
+  spanKind?: SpanKind;
+  spanAdditionalAttributes?: Attributes;
+  serviceName?: string;
+  spanPrefix?: string;
 };
 
-export const defaultSkipError = isOriginalGraphQLError;
-
-export const useSentry = <PluginContext extends Record<string, any> = {}>(
-  options: SentryPluginOptions<PluginContext> = {},
-): Plugin<PluginContext> => {
-  function pick<K extends keyof SentryPluginOptions<PluginContext>>(
-    key: K,
-    defaultValue: NonNullable<SentryPluginOptions<PluginContext>[K]>,
-  ) {
-    return options[key] ?? defaultValue;
+export const useSentry = <PluginContext extends Record<string, any> = {}>({
+  otel = {},
+  tracingProvider,
+  spanKind,
+  spanAdditionalAttributes,
+  serviceName,
+  spanPrefix,
+}: SentryPluginOptions = {}): Plugin<PluginContext> => {
+  const client = Sentry.getClient();
+  if (!client) {
+    throw new Error(
+      "Sentry is not initialized. This plugin doesn't initialize Sentry automatically" +
+        'Please call `Sentry.init` as describe in Sentry documentation',
+    );
   }
 
-  const startTransaction = pick('startTransaction', true);
-  const includeRawResult = pick('includeRawResult', false);
-  const includeExecuteVariables = pick('includeExecuteVariables', false);
-  const renameTransaction = pick('renameTransaction', false);
-  const skipOperation = pick('skip', () => false);
-  const skipError = pick('skipError', defaultSkipError);
+  if (!tracingProvider) {
+    const provider = new BasicTracerProvider({
+      sampler: new SentrySampler(client as Client),
+    });
+    provider.addSpanProcessor(new SentrySpanProcessor());
+    provider.register({
+      propagator: new SentryPropagator(),
+      contextManager: new Sentry.SentryContextManager(),
+    });
 
-  const eventIdKey = options.eventIdKey === null ? null : 'sentryEventId';
-
-  function addEventId(err: GraphQLError, eventId: string | null): GraphQLError {
-    if (eventIdKey !== null && eventId !== null) {
-      err.extensions[eventIdKey] = eventId;
-    }
-
-    return err;
+    Sentry.validateOpenTelemetrySetup();
+    tracingProvider = provider;
   }
 
   return {
-    onExecute({ args }) {
-      if (skipOperation(args)) {
-        return;
-      }
-
-      const rootOperation = args.document.definitions.find(
-        // @ts-expect-error TODO: not sure how we will make it dev friendly
-        o => o.kind === Kind.OPERATION_DEFINITION,
-      ) as OperationDefinitionNode;
-      const operationType = rootOperation.operation;
-
-      const document = getDocumentString(args.document, print);
-
-      const opName = args.operationName || rootOperation.name?.value || 'Anonymous Operation';
-      const addedTags: Record<string, any> = (options.appendTags && options.appendTags(args)) || {};
-      const traceparentData = (options.traceparentData && options.traceparentData(args)) || {};
-
-      const transactionName = options.transactionName ? options.transactionName(args) : opName;
-      const op = options.operationName ? options.operationName(args) : 'execute';
-      const tags = {
-        operationName: opName,
-        operation: operationType,
-        ...addedTags,
-      };
-
-      let rootSpan: Span | undefined;
-
-      if (startTransaction) {
-        Sentry.startSpan(
-          {
-            name: transactionName,
-            op,
-            attributes: tags,
-            ...traceparentData,
-          },
-          span => {
-            rootSpan = span;
-          },
-        );
-
-        if (!rootSpan) {
-          const error = [
-            `Could not create the root Sentry transaction for the GraphQL operation "${transactionName}".`,
-            `It's very likely that this is because you have not included the Sentry tracing SDK in your app's runtime before handling the request.`,
-          ];
-          throw new Error(error.join('\n'));
-        }
-      } else {
-        let childSpan: Span | undefined;
-        const scope = Sentry.getCurrentScope();
-        const parentSpan = scope?.getScopeData().span;
-        if (!parentSpan) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            [
-              `Flag "startTransaction" is disabled but Sentry failed to find a transaction.`,
-              `Try to create a transaction before GraphQL execution phase is started.`,
-            ].join('\n'),
-          );
-          return {};
-        }
-        Sentry.withActiveSpan(parentSpan, () => {
-          Sentry.startSpan(
-            {
-              name: transactionName,
-              op,
-              attributes: tags,
-            },
-            span => {
-              childSpan = span;
-            },
-          );
-        });
-
-        if (!childSpan) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            [
-              `Flag "startTransaction" is disabled but Sentry failed to find a transaction.`,
-              `Try to create a transaction before GraphQL execution phase is started.`,
-            ].join('\n'),
-          );
-          return {};
-        }
-
-        rootSpan = childSpan;
-
-        if (renameTransaction) {
-          scope!.setTransactionName(transactionName);
-        }
-      }
-
-      rootSpan.setAttribute('document', document);
-
-      if (options.configureScope) {
-        options.configureScope(args, Sentry.getCurrentScope());
-      }
-
-      return {
-        onExecuteDone(payload) {
-          const handleResult: OnExecuteDoneHookResultOnNextHook<{}> = ({ result, setResult }) => {
-            if (includeRawResult) {
-              // @ts-expect-error TODO: not sure if this is correct
-              rootSpan?.setAttribute('result', result);
-            }
-
-            if (result.errors && result.errors.length > 0) {
-              Sentry.withScope(scope => {
-                scope.setTransactionName(opName);
-                scope.setTag('operation', operationType);
-                scope.setTag('operationName', opName);
-                scope.setExtra('document', document);
-
-                scope.setTags(addedTags || {});
-
-                if (includeRawResult) {
-                  scope.setExtra('result', result);
-                }
-
-                if (includeExecuteVariables) {
-                  scope.setExtra('variables', args.variableValues);
-                }
-
-                const errors = result.errors?.map(err => {
-                  if (skipError(err) === true) {
-                    return err;
-                  }
-
-                  const errorPath = (err.path ?? [])
-                    .map((v: string | number) => (typeof v === 'number' ? '$index' : v))
-                    .join(' > ');
-
-                  if (errorPath) {
-                    scope.addBreadcrumb({
-                      category: 'execution-path',
-                      message: errorPath,
-                      level: 'debug',
-                    });
-                  }
-
-                  const eventId = Sentry.captureException(err.originalError, {
-                    fingerprint: ['graphql', errorPath, opName, operationType],
-                    contexts: {
-                      GraphQL: {
-                        operationName: opName,
-                        operationType,
-                        variables: args.variableValues,
-                      },
-                    },
-                  });
-
-                  return addEventId(err, eventId);
-                });
-
-                setResult({
-                  ...result,
-                  errors,
-                });
-              });
-            }
-
-            rootSpan?.end();
-          };
-          return handleStreamOrSingleExecutionResult(payload, handleResult);
-        },
-      };
+    onPluginInit({ addPlugin }) {
+      addPlugin(
+        // @ts-expect-error TODO: fix types
+        useOpenTelemetry(
+          otel ?? {},
+          tracingProvider,
+          spanKind,
+          spanAdditionalAttributes,
+          serviceName,
+          spanPrefix,
+        ),
+      );
     },
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1483,7 +1483,7 @@ importers:
         specifier: ^7.114.0
         version: 7.114.0
       '@sentry/types':
-        specifier: ^8.22.0
+        specifier: ^8.32.0
         version: 8.40.0
       graphql:
         specifier: 16.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1457,6 +1457,9 @@ importers:
 
   packages/plugins/sentry:
     dependencies:
+      '@envelop/opentelemetry':
+        specifier: workspace:^
+        version: link:../opentelemetry/dist
       '@opentelemetry/api':
         specifier: ^1.8.0
         version: 1.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1457,6 +1457,15 @@ importers:
 
   packages/plugins/sentry:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.9.0
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.11.0
+        version: 1.26.0(@opentelemetry/api@1.9.0)
+      '@sentry/opentelemetry':
+        specifier: ^8.40.0
+        version: 8.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0
@@ -1475,7 +1484,7 @@ importers:
         version: 7.114.0
       '@sentry/types':
         specifier: ^8.22.0
-        version: 8.32.0
+        version: 8.40.0
       graphql:
         specifier: 16.6.0
         version: 16.6.0
@@ -4348,6 +4357,10 @@ packages:
     resolution: {integrity: sha512-+xidTr0lZ0c755tq4k75dXPEb8PA+qvIefW3U9+dQMORLokBrYoKYMf5zZTG2k/OfSJS6OSxatUj36NFuCs3aA==}
     engines: {node: '>=14.18'}
 
+  '@sentry/core@8.40.0':
+    resolution: {integrity: sha512-u/U2CJpG/+SmTR2bPM4ZZoPYTJAOUuxzj/0IURnvI0v9+rNu939J/fzrO9huA5IJVxS5TiYykhQm7o6I3Zuo3Q==}
+    engines: {node: '>=14.18'}
+
   '@sentry/node@8.0.0':
     resolution: {integrity: sha512-yOmJV0gyRA5KMw4lUAuB2LytUwcwSByjFn2KO5Xy9Oc8XpgJ91CIU/v1Udv3GsrYo2HpdQn/dyZLwqqhbyM55Q==}
     engines: {node: '>=14.18'}
@@ -4376,6 +4389,16 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.26.0
       '@opentelemetry/semantic-conventions': ^1.27.0
 
+  '@sentry/opentelemetry@8.40.0':
+    resolution: {integrity: sha512-kW9EBRESjNnBdj2zCqNMv8x0VIsmiALIOMpi25Dpm38IKtRg/ckQ7YOWx1lnT3iOFebO2GXUvOu+gPmuzIY2WQ==}
+    engines: {node: '>=14.18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.25.1
+      '@opentelemetry/instrumentation': ^0.54.0
+      '@opentelemetry/sdk-trace-base': ^1.26.0
+      '@opentelemetry/semantic-conventions': ^1.27.0
+
   '@sentry/tracing@7.114.0':
     resolution: {integrity: sha512-eldEYGADReZ4jWdN5u35yxLUSTOvjsiZAYd4KBEpf+Ii65n7g/kYOKAjNl7tHbrEG1EsMW4nDPWStUMk1w+tfg==}
     engines: {node: '>=8'}
@@ -4390,6 +4413,10 @@ packages:
 
   '@sentry/types@8.32.0':
     resolution: {integrity: sha512-hxckvN2MzS5SgGDgVQ0/QpZXk13Vrq4BtZLwXhPhyeTmZtUiUfWvcL5TFQqLinfKdTKPe9q2MxeAJ0D4LalhMg==}
+    engines: {node: '>=14.18'}
+
+  '@sentry/types@8.40.0':
+    resolution: {integrity: sha512-nuCf3U3deolPM9BjNnwCc33UtFl9ec15/r74ngAkNccn+A2JXdIAsDkGJMO/9mgSFykLe1QyeJ0pQFRisCGOiA==}
     engines: {node: '>=14.18'}
 
   '@sentry/utils@7.114.0':
@@ -7542,9 +7569,9 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
 
-  hash-base@3.0.4:
-    resolution: {integrity: sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==}
-    engines: {node: '>=4'}
+  hash-base@3.0.5:
+    resolution: {integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==}
+    engines: {node: '>= 0.10'}
 
   hash-it@6.0.0:
     resolution: {integrity: sha512-KHzmSFx1KwyMPw0kXeeUD752q/Kfbzhy6dAZrjXV9kAIXGqzGvv8vhkUqj+2MGZldTo0IBpw6v7iWE7uxsvH0w==}
@@ -11811,7 +11838,7 @@ snapshots:
       '@apollo/utils.fetcher': 1.1.1
       '@apollo/utils.logger': 1.0.1
       '@josephg/resolvable': 1.0.1
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
       '@types/node-fetch': 2.6.2
       apollo-reporting-protobuf: 3.2.0
       async-retry: 1.3.3
@@ -14783,11 +14810,11 @@ snapshots:
 
   '@opentelemetry/api-logs@0.50.0':
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
 
   '@opentelemetry/api-logs@0.51.1':
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
 
   '@opentelemetry/api-logs@0.52.1':
     dependencies:
@@ -14805,10 +14832,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.8.0
 
-  '@opentelemetry/context-async-hooks@1.26.0(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-
   '@opentelemetry/context-async-hooks@1.26.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -14823,15 +14846,10 @@ snapshots:
       '@opentelemetry/api': 1.8.0
       '@opentelemetry/semantic-conventions': 1.23.0
 
-  '@opentelemetry/core@1.24.1(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/core@1.24.1(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.24.1
-
-  '@opentelemetry/core@1.26.0(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/semantic-conventions': 1.27.0
 
   '@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -14847,11 +14865,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-connect@0.35.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-connect@0.35.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@types/connect': 3.4.36
     transitivePeerDependencies:
@@ -14874,11 +14892,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-express@0.35.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-express@0.35.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.48.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.48.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -14892,11 +14910,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-fastify@0.35.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-fastify@0.35.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -14925,10 +14943,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-graphql@0.39.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-graphql@0.39.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14939,11 +14957,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-hapi@0.38.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-hapi@0.38.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -14957,11 +14975,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-http@0.51.1(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-http@0.51.1(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.24.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.24.1
       semver: 7.6.3
     transitivePeerDependencies:
@@ -14977,10 +14995,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.40.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-ioredis@0.40.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/redis-common': 0.36.2
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
@@ -15003,11 +15021,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-koa@0.39.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-koa@0.39.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@types/koa': 2.14.0
       '@types/koa__router': 12.0.3
@@ -15023,11 +15041,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongodb@0.39.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-mongodb@0.39.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.48.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/sdk-metrics': 1.26.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.48.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -15041,11 +15059,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongoose@0.37.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-mongoose@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -15059,12 +15077,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql2@0.37.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-mysql2@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
-      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15077,10 +15095,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql@0.37.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-mysql@0.37.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@types/mysql': 2.15.22
     transitivePeerDependencies:
@@ -15095,10 +15113,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-nestjs-core@0.36.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-nestjs-core@0.36.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -15111,12 +15129,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.40.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation-pg@0.40.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.50.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
-      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
       '@types/pg': 8.6.1
       '@types/pg-pool': 2.0.4
     transitivePeerDependencies:
@@ -15150,9 +15168,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.43.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation@0.43.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.4.2
       require-in-the-middle: 7.2.0
@@ -15162,9 +15180,9 @@ snapshots:
       - supports-color
     optional: true
 
-  '@opentelemetry/instrumentation@0.48.0(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation@0.48.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.7.1
       require-in-the-middle: 7.2.0
@@ -15185,9 +15203,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.8.0)':
+  '@opentelemetry/instrumentation@0.50.0(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.50.0
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.7.1
+      require-in-the-middle: 7.2.0
+      semver: 7.6.3
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.51.1
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.7.4
@@ -15235,23 +15265,11 @@ snapshots:
       '@opentelemetry/core': 1.23.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.23.0
 
-  '@opentelemetry/resources@1.26.0(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.27.0
-
   '@opentelemetry/resources@1.26.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
-
-  '@opentelemetry/sdk-metrics@1.26.0(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.8.0)
 
   '@opentelemetry/sdk-metrics@1.26.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15273,13 +15291,6 @@ snapshots:
       '@opentelemetry/resources': 1.23.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.23.0
 
-  '@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.27.0
-
   '@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -15294,11 +15305,6 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.24.1': {}
 
   '@opentelemetry/semantic-conventions@1.27.0': {}
-
-  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.8.0)':
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
 
   '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15413,32 +15419,36 @@ snapshots:
       '@sentry/types': 8.32.0
       '@sentry/utils': 8.32.0
 
+  '@sentry/core@8.40.0':
+    dependencies:
+      '@sentry/types': 8.40.0
+
   '@sentry/node@8.0.0':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/context-async-hooks': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-connect': 0.35.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-express': 0.35.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-fastify': 0.35.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-graphql': 0.39.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-hapi': 0.38.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-http': 0.51.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-ioredis': 0.40.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-koa': 0.39.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-mongodb': 0.39.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-mongoose': 0.37.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-mysql': 0.37.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-mysql2': 0.37.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-nestjs-core': 0.36.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation-pg': 0.40.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-connect': 0.35.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-express': 0.35.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-fastify': 0.35.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-graphql': 0.39.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-hapi': 0.38.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.51.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-ioredis': 0.40.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-koa': 0.39.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongodb': 0.39.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mongoose': 0.37.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql': 0.37.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-mysql2': 0.37.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-nestjs-core': 0.36.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-pg': 0.40.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@prisma/instrumentation': 5.13.0
       '@sentry/core': 8.0.0
-      '@sentry/opentelemetry': 8.0.0(@opentelemetry/api@1.8.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.8.0))(@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.8.0))(@opentelemetry/semantic-conventions@1.27.0)
+      '@sentry/opentelemetry': 8.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)
       '@sentry/types': 8.0.0
       '@sentry/utils': 8.0.0
     optionalDependencies:
@@ -15485,12 +15495,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@8.0.0(@opentelemetry/api@1.8.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.8.0))(@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.8.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.8.0))(@opentelemetry/semantic-conventions@1.27.0)':
+  '@sentry/opentelemetry@8.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)':
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
       '@sentry/core': 8.0.0
       '@sentry/types': 8.0.0
@@ -15507,6 +15517,16 @@ snapshots:
       '@sentry/types': 8.32.0
       '@sentry/utils': 8.32.0
 
+  '@sentry/opentelemetry@8.40.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.27.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.53.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.27.0
+      '@sentry/core': 8.40.0
+      '@sentry/types': 8.40.0
+
   '@sentry/tracing@7.114.0':
     dependencies:
       '@sentry-internal/tracing': 7.114.0
@@ -15516,6 +15536,8 @@ snapshots:
   '@sentry/types@8.0.0': {}
 
   '@sentry/types@8.32.0': {}
+
+  '@sentry/types@8.40.0': {}
 
   '@sentry/utils@7.114.0':
     dependencies:
@@ -17150,7 +17172,7 @@ snapshots:
       create-hash: 1.2.0
       create-hmac: 1.1.7
       elliptic: 6.6.1
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
       parse-asn1: 5.1.7
       readable-stream: 2.3.8
@@ -17690,7 +17712,7 @@ snapshots:
       create-hash: 1.2.0
       create-hmac: 1.1.7
       diffie-hellman: 5.0.3
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
       pbkdf2: 3.1.2
       public-encrypt: 4.0.3
@@ -19557,7 +19579,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hash-base@3.0.4:
+  hash-base@3.0.5:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
@@ -20977,7 +20999,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
@@ -22245,8 +22267,8 @@ snapshots:
 
   opentelemetry-instrumentation-fetch-node@1.2.0:
     dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/instrumentation': 0.43.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/instrumentation': 0.43.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
     transitivePeerDependencies:
       - supports-color
@@ -22335,7 +22357,7 @@ snapshots:
       asn1.js: 4.10.1
       browserify-aes: 1.2.0
       evp_bytestokey: 1.0.3
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       pbkdf2: 3.1.2
       safe-buffer: 5.2.1
 
@@ -22761,7 +22783,7 @@ snapshots:
 
   prom-client@15.1.0:
     dependencies:
-      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api': 1.9.0
       tdigest: 0.1.1
 
   promise-inflight@1.0.1(bluebird@3.7.2):
@@ -23313,7 +23335,7 @@ snapshots:
 
   ripemd160@2.0.2:
     dependencies:
-      hash-base: 3.0.4
+      hash-base: 3.0.5
       inherits: 2.0.4
 
   robust-predicates@3.0.1: {}


### PR DESCRIPTION
This PR is an experiment to use the OTEL plugin instead of duplicating the instrumentation code.
Sentry is supposed to already use OTEL internally, and should be possible to use an existing OTEL setup with it instead of their dedicated SDK.