### PR TITLE
feat(core): allow to use a uniform state in `withState`

### DIFF
--- a/.changeset/curly-carrots-lead.md
+++ b/.changeset/curly-carrots-lead.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+Add a `withState` override to ease the typing of plugins whith the same state for all scopes.

--- a/packages/core/src/plugin-with-state.ts
+++ b/packages/core/src/plugin-with-state.ts
@@ -1,5 +1,10 @@
 import { MaybePromise } from '@whatwg-node/promise-helpers';
 
+export function withState<P extends { instrumentation?: GenericInstrumentation }, State = object>(
+  pluginFactory: (
+    getState: <SP extends {}>(payload: SP) => PayloadWithState<SP, State, State, State>['state'],
+  ) => PluginWithState<P, State, State, State>,
+): P;
 export function withState<
   P extends { instrumentation?: GenericInstrumentation },
   HttpState = object,


### PR DESCRIPTION
The `withState` function takes a hight number of generics.

This is a proposition to ease its usage by allowing to define only one uniform state for all scopes.

An example of this is `useOpentelemetry` which have always the same state for all scopes.