### PR TITLE
fix(withState): respect getters and setters of non hook properties

### DIFF
--- a/.changeset/plain-trams-kneel.md
+++ b/.changeset/plain-trams-kneel.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+---
+
+Fix getters and setters being stripped away. The value was copied at plugin creation instead of
+copying the getter and setter (if any).

--- a/packages/core/src/plugin-with-state.ts
+++ b/packages/core/src/plugin-with-state.ts
@@ -62,9 +62,16 @@ export function withState<
 
   function addStateGetters(src: any) {
     const result: any = {};
-    for (const [hookName, hook] of Object.entries(src) as any) {
+    // Use the property descriptors to keep potential getters and setters, or not enumerable props
+    const properties = Object.entries(Object.getOwnPropertyDescriptors(src));
+    for (const [hookName, descriptor] of properties) {
+      const hook = descriptor.value;
       if (typeof hook !== 'function') {
-        result[hookName] = hook;
+        descriptor.get &&= () => src[hookName];
+        descriptor.set &&= value => {
+          src[hookName] = value;
+        };
+        Object.defineProperty(result, hookName, descriptor);
       } else {
         result[hookName] = {
           [hook.name](payload: any, ...args: any[]) {
@@ -88,11 +95,11 @@ export function withState<
     return result;
   }
 
-  const { instrumentation, ...hooks } = pluginFactory(getState as any);
+  const plugin = pluginFactory(getState as any);
 
-  const pluginWithState = addStateGetters(hooks);
-  if (instrumentation) {
-    pluginWithState.instrumentation = addStateGetters(instrumentation);
+  const pluginWithState = addStateGetters(plugin);
+  if (plugin.instrumentation) {
+    pluginWithState.instrumentation = addStateGetters(plugin.instrumentation);
   }
 
   return pluginWithState as P;

--- a/packages/core/test/plugin-with-state.spec.ts
+++ b/packages/core/test/plugin-with-state.spec.ts
@@ -77,7 +77,35 @@ describe('pluginWithState', () => {
     );
   });
 
-  describe('instruments', () => {
+  it('should allow to have getters and setters', () => {
+    const called = { getter: false, setter: false };
+    const plugin = withState<{ value: string; instrumentation?: never }>(() => ({
+      get value() {
+        called.getter = true;
+        return 'test';
+      },
+      set value(value) {
+        called.setter = true;
+        expect(value).toBe('value');
+      },
+    }));
+
+    plugin.value = 'value';
+    expect(plugin.value).toBe('test');
+    expect(called).toEqual({ getter: true, setter: true });
+  });
+
+  it('should allow to have not enumerable', () => {
+    const plugin = {};
+    Object.defineProperty(plugin, 'hidden', { value: 'test' });
+
+    const pluginWithState = withState(() => plugin);
+    // @ts-expect-error
+    expect(pluginWithState['hidden']).toBe('test');
+    expect(Object.keys(plugin)).toEqual([]);
+  });
+
+  describe('instrumentation', () => {
     const plugin = withState(() => ({ instrumentation: { hook: (...args: any[]): any => args } }));
 
     it('should add request state', () => {


### PR DESCRIPTION
The `withState` plugin utility was not respecting plugin properties with getters or setters.

In particular, properties with getters were just copied at plugin creating time, leading to potential bugs where the getter doesn't always return the same thing over time.

This PR fixes this by enumerating all properties with `Object.getOwnPropertyDescriptors` and iterating over it instead of `Object.entries`. This also allows to keep the `enumerable`, `writable` and `configurable` flags from each non-hooks properties.

See this PR for a usage of this: https://github.com/graphql-hive/gateway/pull/1360