### PR TITLE
Remove empty and unused nodes from redacted query after validation of generic-auth directives

### DIFF
--- a/.changeset/seven-hounds-behave.md
+++ b/.changeset/seven-hounds-behave.md
@@ -1,0 +1,5 @@
+---
+'@envelop/generic-auth': patch
+---
+
+Remove empty and unused nodes from redacted query after validation

--- a/.changeset/young-beans-cross.md
+++ b/.changeset/young-beans-cross.md
@@ -1,0 +1,7 @@
+---
+'@envelop/extended-validation': minor
+---
+
+Introduce new option `onDocument`
+
+It's a callback that is invoked when the document is assembled by the visitor.

--- a/packages/plugins/extended-validation/src/plugin.ts
+++ b/packages/plugins/extended-validation/src/plugin.ts
@@ -175,10 +175,7 @@ function buildHandler(
                 for (const pathItemIndex in path.slice(0, -1)) {
                   const pathItem = path[pathItemIndex];
                   currentData = currentData[pathItem] ||=
-                    typeof path[Number(pathItemIndex) + 1] === 'number' ||
-                    path[Number(pathItemIndex) + 1]
-                      ? []
-                      : {};
+                    typeof path[Number(pathItemIndex) + 1] === 'number' ? [] : {};
                   if (Array.isArray(currentData)) {
                     let pathItemIndexInArray = Number(pathItemIndex) + 1;
                     if (path[pathItemIndexInArray] === '@') {

--- a/packages/plugins/extended-validation/src/plugin.ts
+++ b/packages/plugins/extended-validation/src/plugin.ts
@@ -1,4 +1,5 @@
 import {
+  DocumentNode,
   ExecutionArgs,
   ExecutionResult,
   GraphQLError,
@@ -34,6 +35,10 @@ type OnValidationFailedCallback = (params: {
 
 export const useExtendedValidation = <PluginContext extends Record<string, any> = {}>(options: {
   rules: Array<ExtendedValidationRule>;
+  /**
+   * Callback that is invoked when the document is assembled by the visitor.
+   */
+  onDocument?: (document: DocumentNode) => DocumentNode;
   /**
    * Callback that is invoked if the extended validation yields any errors.
    */
@@ -74,12 +79,14 @@ export const useExtendedValidation = <PluginContext extends Record<string, any> 
     onSubscribe: buildHandler(
       'subscribe',
       getTypeInfo,
+      options.onDocument,
       options.onValidationFailed,
       options.rejectOnErrors !== false,
     ),
     onExecute: buildHandler(
       'execute',
       getTypeInfo,
+      options.onDocument,
       options.onValidationFailed,
       options.rejectOnErrors !== false,
     ),
@@ -89,6 +96,7 @@ export const useExtendedValidation = <PluginContext extends Record<string, any> 
 function buildHandler(
   name: 'execute' | 'subscribe',
   getTypeInfo: () => TypeInfo | undefined,
+  onDocument?: (document: DocumentNode) => DocumentNode,
   onValidationFailed?: OnValidationFailedCallback,
   rejectOnErrors = true,
 ) {
@@ -127,6 +135,9 @@ function buildHandler(
         );
 
         args.document = visit(args.document, visitWithTypeInfo(typeInfo, visitor));
+        if (onDocument) {
+          args.document = onDocument(args.document);
+        }
 
         if (errors.length > 0) {
           if (rejectOnErrors) {

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -27,7 +27,7 @@ import {
   shouldIncludeNode,
 } from '@graphql-tools/utils';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
-import { removeEmptyOrUnusedNodes } from './utils';
+import { removeEmptyOrUnusedNodes } from './utils.js';
 
 export type ResolveUserFn<UserType, ContextType = DefaultContext> = (
   context: ContextType,

--- a/packages/plugins/generic-auth/src/index.ts
+++ b/packages/plugins/generic-auth/src/index.ts
@@ -27,6 +27,7 @@ import {
   shouldIncludeNode,
 } from '@graphql-tools/utils';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
+import { removeEmptyOrUnusedNodes } from './utils';
 
 export type ResolveUserFn<UserType, ContextType = DefaultContext> = (
   context: ContextType,
@@ -316,6 +317,7 @@ export const useGenericAuth = <
         addPlugin(
           useExtendedValidation({
             rejectOnErrors: rejectUnauthenticated,
+            onDocument: removeEmptyOrUnusedNodes,
             rules: [
               function AuthorizationExtendedValidationRule(context, args) {
                 const user = (args.contextValue as any)[contextFieldName];

--- a/packages/plugins/generic-auth/src/utils.ts
+++ b/packages/plugins/generic-auth/src/utils.ts
@@ -1,6 +1,149 @@
-import { DocumentNode } from 'graphql';
+import {
+  DocumentNode,
+  DefinitionNode,
+  OperationDefinitionNode,
+  FragmentDefinitionNode,
+  SelectionSetNode,
+  SelectionNode,
+  FieldNode,
+  InlineFragmentNode,
+  FragmentSpreadNode,
+} from 'graphql';
 
 export function sanitizeDocument(documentNode: DocumentNode): DocumentNode {
-  // TODO: implement
-  return documentNode;
+  let changed = true;
+  let document = { ...documentNode, definitions: [...documentNode.definitions] };
+
+  while (changed) {
+    changed = false;
+
+    // Build a map of fragment definitions
+    const fragmentMap = new Map<string, FragmentDefinitionNode>();
+    for (const definition of document.definitions) {
+      if (definition.kind === 'FragmentDefinition') {
+        fragmentMap.set(definition.name.value, definition);
+      }
+    }
+
+    // Sanitize each operation definition
+    document.definitions = document.definitions.map((def) => {
+      if (def.kind === 'OperationDefinition') {
+        const sanitized = sanitizeSelectionSet(def.selectionSet, fragmentMap);
+        if (sanitized !== def.selectionSet) {
+          changed = true;
+        }
+        return { ...def, selectionSet: sanitized };
+      }
+      return def;
+    });
+
+    // Rebuild fragment map after sanitization
+    const newFragmentMap = new Map<string, FragmentDefinitionNode>();
+    for (const definition of document.definitions) {
+      if (definition.kind === 'FragmentDefinition') {
+        newFragmentMap.set(definition.name.value, definition);
+      }
+    }
+
+    // Remove unused fragments
+    const usedFragmentNames = new Set<string>();
+    for (const definition of document.definitions) {
+      if (definition.kind === 'OperationDefinition') {
+        collectUsedFragments(definition.selectionSet, newFragmentMap, usedFragmentNames);
+      }
+    }
+
+    const filteredDefinitions = document.definitions.filter((def) => {
+      if (def.kind === 'FragmentDefinition') {
+        return usedFragmentNames.has(def.name.value);
+      }
+      return true;
+    });
+
+    if (filteredDefinitions.length !== document.definitions.length) {
+      changed = true;
+    }
+
+    document = { ...document, definitions: filteredDefinitions };
+  }
+
+  return document;
+}
+
+function sanitizeSelectionSet(
+  selectionSet: SelectionSetNode,
+  fragmentMap: Map<string, FragmentDefinitionNode>
+): SelectionSetNode {
+  let selections = [...selectionSet.selections];
+
+  // First pass: sanitize child selection sets
+  selections = selections.map((selection) => {
+    if (selection.kind === 'Field') {
+      if (selection.selectionSet) {
+        const sanitized = sanitizeSelectionSet(selection.selectionSet, fragmentMap);
+        return { ...selection, selectionSet: sanitized };
+      }
+    } else if (selection.kind === 'InlineFragment') {
+      const sanitized = sanitizeSelectionSet(selection.selectionSet, fragmentMap);
+      return { ...selection, selectionSet: sanitized };
+    }
+    return selection;
+  });
+
+  // Second pass: remove empty inline fragments
+  selections = selections.filter((selection) => {
+    if (selection.kind === 'InlineFragment') {
+      if (selection.selectionSet.selections.length === 0) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  // Third pass: remove fields with empty selection sets (unless they have no selectionSet at all)
+  selections = selections.filter((selection) => {
+    if (selection.kind === 'Field') {
+      if (selection.selectionSet && selection.selectionSet.selections.length === 0) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  // Fourth pass: remove fragment spreads that reference empty fragments
+  selections = selections.filter((selection) => {
+    if (selection.kind === 'FragmentSpread') {
+      const fragment = fragmentMap.get(selection.name.value);
+      if (fragment && fragment.selectionSet.selections.length === 0) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  if (selections.length !== selectionSet.selections.length) {
+    return { ...selectionSet, selections };
+  }
+
+  return selectionSet;
+}
+
+function collectUsedFragments(
+  selectionSet: SelectionSetNode,
+  fragmentMap: Map<string, FragmentDefinitionNode>,
+  usedFragments: Set<string>
+): void {
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === 'Field' && selection.selectionSet) {
+      collectUsedFragments(selection.selectionSet, fragmentMap, usedFragments);
+    } else if (selection.kind === 'InlineFragment' && selection.selectionSet) {
+      collectUsedFragments(selection.selectionSet, fragmentMap, usedFragments);
+    } else if (selection.kind === 'FragmentSpread') {
+      usedFragments.add(selection.name.value);
+      const fragment = fragmentMap.get(selection.name.value);
+      if (fragment && fragment.selectionSet) {
+        collectUsedFragments(fragment.selectionSet, fragmentMap, usedFragments);
+      }
+    }
+  }
 }

--- a/packages/plugins/generic-auth/src/utils.ts
+++ b/packages/plugins/generic-auth/src/utils.ts
@@ -1,0 +1,6 @@
+import { DocumentNode } from 'graphql';
+
+export function sanitizeDocument(documentNode: DocumentNode): DocumentNode {
+  // TODO: implement
+  return documentNode;
+}

--- a/packages/plugins/generic-auth/src/utils.ts
+++ b/packages/plugins/generic-auth/src/utils.ts
@@ -1,7 +1,7 @@
 import { DocumentNode, FragmentDefinitionNode, SelectionSetNode } from 'graphql';
 
 /**
- * Sanitizes a GraphQL document node by removing empty and unused elements.
+ * Sanitizes a GraphQL document node by removing empty and unused nodes.
  * This includes:
  * - Empty inline fragments
  * - Fields with empty selection sets

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -448,6 +448,17 @@ describe('useGenericAuth', () => {
             }
           }
         `,
+        /* GraphQL */ `
+          query {
+            public
+            person {
+              ...A
+            }
+          }
+          fragment A on Admin {
+            email
+          }
+        `,
       ]) {
         const result = await testInstance.execute(query);
         assertSingleExecutionValue(result);
@@ -459,9 +470,7 @@ describe('useGenericAuth', () => {
                   name: 'John',
                   email: null,
                 }
-              : {
-                  email: null,
-                },
+              : null,
           },
           errors: [
             {
@@ -479,6 +488,9 @@ describe('useGenericAuth', () => {
          person {
            name
          }
+       }",
+         "{
+         public
        }",
          "{
          public

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -474,7 +474,7 @@ describe('useGenericAuth', () => {
           },
           errors: [
             {
-              message: `Unauthorized field or type`,
+              message: 'Unauthorized field or type',
               path: ['person', 'email'],
             },
           ],

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -418,7 +418,7 @@ describe('useGenericAuth', () => {
           }),
           {
             onExecute({ args }) {
-              redactedQuery = print(args.document);
+              redactedQuery = print(args.document).trim();
             },
           },
         ],
@@ -465,7 +465,7 @@ describe('useGenericAuth', () => {
 
     // TODO: broken
     it.skip('Should prevent inline fragment of protected type execution when user is not authenticated correctly but continue execution for public fields outside the parent', async () => {
-      const reducedQueries = [] as string[];
+      let redactedQuery = '';
       const testInstance = createTestkit(
         [
           useGenericAuth({
@@ -475,7 +475,7 @@ describe('useGenericAuth', () => {
           }),
           {
             onExecute({ args }) {
-              reducedQueries.push(print(args.document));
+              redactedQuery = print(args.document).trim();
             },
           },
         ],
@@ -496,7 +496,9 @@ describe('useGenericAuth', () => {
       expect(result).toMatchObject({
         data: {
           public: 'public',
-          person: null,
+          person: {
+            email: null,
+          },
         },
         errors: [
           {
@@ -506,18 +508,16 @@ describe('useGenericAuth', () => {
         ],
       });
 
-      expect(reducedQueries).toMatchInlineSnapshot(`
-       [
-         "{
+      expect(redactedQuery).toMatchInlineSnapshot(`
+       "{
          public
-       }",
-       ]
+       }"
       `);
     });
 
     // TODO: broken
     it.skip('Should prevent fragment definition of protected type execution when user is not authenticated correctly but continue execution for public fields outside the parent', async () => {
-      const reducedQueries = [] as string[];
+      let redactedQuery = '';
       const testInstance = createTestkit(
         [
           useGenericAuth({
@@ -527,7 +527,7 @@ describe('useGenericAuth', () => {
           }),
           {
             onExecute({ args }) {
-              reducedQueries.push(print(args.document));
+              redactedQuery = print(args.document).trim();
             },
           },
         ],
@@ -548,7 +548,9 @@ describe('useGenericAuth', () => {
       assertSingleExecutionValue(result);
       expect(result.data).toEqual({
         public: 'public',
-        person: null,
+        person: {
+          email: null,
+        },
       });
       expect(result.errors).toMatchObject([
         {
@@ -557,12 +559,10 @@ describe('useGenericAuth', () => {
         },
       ]);
 
-      expect(reducedQueries).toMatchInlineSnapshot(`
-       [
-         "{
+      expect(redactedQuery).toMatchInlineSnapshot(`
+       "{
          public
-       }",
-       ]
+       }"
       `);
     });
 

--- a/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
+++ b/packages/plugins/generic-auth/tests/use-generic-auth.spec.ts
@@ -463,8 +463,7 @@ describe('useGenericAuth', () => {
       `);
     });
 
-    // TODO: broken
-    it.skip('Should prevent inline fragment of protected type execution when user is not authenticated correctly but continue execution for public fields outside the parent', async () => {
+    it('Should prevent inline fragment of protected type execution when user is not authenticated correctly but continue execution for public fields outside the parent', async () => {
       let redactedQuery = '';
       const testInstance = createTestkit(
         [
@@ -515,8 +514,7 @@ describe('useGenericAuth', () => {
       `);
     });
 
-    // TODO: broken
-    it.skip('Should prevent fragment definition of protected type execution when user is not authenticated correctly but continue execution for public fields outside the parent', async () => {
+    it('Should prevent fragment definition of protected type execution when user is not authenticated correctly but continue execution for public fields outside the parent', async () => {
       let redactedQuery = '';
       const testInstance = createTestkit(
         [
@@ -546,18 +544,18 @@ describe('useGenericAuth', () => {
         }
       `);
       assertSingleExecutionValue(result);
-      expect(result.data).toEqual({
-        public: 'public',
-        person: {
-          email: null,
-        },
-      });
       expect(result.errors).toMatchObject([
         {
           message: 'Unauthorized field or type',
           path: ['person', 'email'],
         },
       ]);
+      expect(result.data).toEqual({
+        public: 'public',
+        person: {
+          email: null,
+        },
+      });
 
       expect(redactedQuery).toMatchInlineSnapshot(`
        "{

--- a/packages/plugins/generic-auth/tests/utils.spec.ts
+++ b/packages/plugins/generic-auth/tests/utils.spec.ts
@@ -1,5 +1,5 @@
 import { parse, print } from 'graphql';
-import { sanitizeDocument } from '../src/utils';
+import { removeEmptyOrUnusedNodes } from '../src/utils';
 
 it('removes inline fragment spreads that are empty', () => {
   const document = parse(/* GraphQL */ `
@@ -21,7 +21,7 @@ it('removes inline fragment spreads that are empty', () => {
    }"
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      name
@@ -47,7 +47,7 @@ it('empties the whole document when no fields remain', () => {
    }"
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toBe('');
 });
 
@@ -79,7 +79,7 @@ it('removes inline fragment spreads and parent field when empty', () => {
    }"
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      name
@@ -114,7 +114,7 @@ it('removes fragment spreads that reference empty fragments with leftover empty 
    fragment A on Admin "
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      name
@@ -159,7 +159,7 @@ it('removes nested inline fragments and bubbles to parent field', () => {
    }"
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      user {
@@ -203,7 +203,7 @@ it('recursively removes fragments referencing other fragments that are empty', (
    fragment B on User "
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      hello
@@ -224,7 +224,7 @@ it('removes unused fragment definitions', () => {
     }
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      name
@@ -265,7 +265,7 @@ it('removes all fields referencing empty fragments', () => {
    fragment A on Admin "
   `);
 
-  const sanitized = sanitizeDocument(document);
+  const sanitized = removeEmptyOrUnusedNodes(document);
   expect(print(sanitized)).toMatchInlineSnapshot(`
    "{
      hello

--- a/packages/plugins/generic-auth/tests/utils.spec.ts
+++ b/packages/plugins/generic-auth/tests/utils.spec.ts
@@ -1,0 +1,101 @@
+import { parse, print } from 'graphql';
+import { sanitizeDocument } from '../src/utils';
+
+it('removes inline fragment spreads that are empty', () => {
+  const document = parse(/* GraphQL */ `
+    {
+      name
+      ... on Admin {
+        email
+      }
+    }
+  `);
+
+  // @ts-expect-error break it
+  document.definitions[0].selectionSet.selections[1].selectionSet.selections = [];
+
+  expect(print(document)).toMatchInlineSnapshot(`
+   "{
+     name
+     ... on Admin
+   }"
+  `);
+
+  const sanitized = sanitizeDocument(document);
+  expect(print(sanitized)).toMatchInlineSnapshot(`
+   "{
+     name
+   }"
+  `);
+});
+
+it('removes inline fragment spreads and parent field when empty', () => {
+  const document = parse(
+    /* GraphQL */ `
+      {
+        name
+        person {
+          ... on Admin {
+            email
+          }
+        }
+      }
+    `,
+    { noLocation: true },
+  );
+
+  // @ts-expect-error break it
+  document.definitions[0].selectionSet.selections[1].selectionSet.selections[0].selectionSet.selections =
+    [];
+
+  expect(print(document)).toMatchInlineSnapshot(`
+   "{
+     name
+     person {
+       ... on Admin
+     }
+   }"
+  `);
+
+  const sanitized = sanitizeDocument(document);
+  expect(print(sanitized)).toMatchInlineSnapshot(`
+   "{
+     name
+   }"
+  `);
+});
+
+it('removes fragment spreads that reference empty fragments with leftover empty parent field', () => {
+  const document = parse(/* GraphQL */ `
+    {
+      name
+      person {
+        ...A
+      }
+    }
+    fragment A on Admin {
+      email
+    }
+  `);
+
+  // @ts-expect-error break it
+  document.definitions[1].selectionSet.selections = [];
+
+  expect(print(document)).toMatchInlineSnapshot(`
+   "{
+     name
+     person {
+       ...A
+     }
+   }
+
+   fragment A on Admin "
+  `);
+
+  const sanitized = sanitizeDocument(document);
+  expect(print(sanitized)).toMatchInlineSnapshot(`
+   "{
+     name
+   }"
+  `);
+});

--- a/packages/plugins/generic-auth/tests/utils.spec.ts
+++ b/packages/plugins/generic-auth/tests/utils.spec.ts
@@ -14,7 +14,7 @@ it('removes inline fragment spreads that are empty', () => {
   // @ts-expect-error break it
   document.definitions[0].selectionSet.selections[1].selectionSet.selections = [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      name
      ... on Admin
@@ -22,7 +22,7 @@ it('removes inline fragment spreads that are empty', () => {
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      name
    }"
@@ -41,14 +41,14 @@ it('empties the whole document when no fields remain', () => {
   // @ts-expect-error break it
   document.definitions[0].selectionSet.selections[0].selectionSet.selections = [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      ... on Admin
    }"
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toBe('');
+  expect(print(sanitized).trim()).toBe('');
 });
 
 it('removes inline fragment spreads and parent field when empty', () => {
@@ -70,7 +70,7 @@ it('removes inline fragment spreads and parent field when empty', () => {
   document.definitions[0].selectionSet.selections[1].selectionSet.selections[0].selectionSet.selections =
     [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      name
      person {
@@ -80,7 +80,7 @@ it('removes inline fragment spreads and parent field when empty', () => {
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      name
    }"
@@ -103,7 +103,7 @@ it('removes fragment spreads that reference empty fragments with leftover empty 
   // @ts-expect-error break it
   document.definitions[1].selectionSet.selections = [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      name
      person {
@@ -115,7 +115,7 @@ it('removes fragment spreads that reference empty fragments with leftover empty 
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      name
    }"
@@ -144,7 +144,7 @@ it('removes nested inline fragments and bubbles to parent field', () => {
   document.definitions[0].selectionSet.selections[0].selectionSet.selections[1].selectionSet.selections[0].selectionSet.selections[0].selectionSet.selections[0].selectionSet.selections =
     [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      user {
        name
@@ -160,7 +160,7 @@ it('removes nested inline fragments and bubbles to parent field', () => {
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      user {
        name
@@ -188,7 +188,7 @@ it('recursively removes fragments referencing other fragments that are empty', (
   // @ts-expect-error break it
   document.definitions[2].selectionSet.selections = [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      hello
      user {
@@ -204,7 +204,7 @@ it('recursively removes fragments referencing other fragments that are empty', (
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      hello
    }"
@@ -225,7 +225,7 @@ it('removes unused fragment definitions', () => {
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      name
    }"
@@ -251,7 +251,7 @@ it('removes all fields referencing empty fragments', () => {
   // @ts-expect-error break it
   document.definitions[1].selectionSet.selections = [];
 
-  expect(print(document)).toMatchInlineSnapshot(`
+  expect(print(document).trim()).toMatchInlineSnapshot(`
    "{
      hello
      admin {
@@ -266,7 +266,7 @@ it('removes all fields referencing empty fragments', () => {
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
-  expect(print(sanitized)).toMatchInlineSnapshot(`
+  expect(print(sanitized).trim()).toMatchInlineSnapshot(`
    "{
      hello
    }"

--- a/packages/plugins/generic-auth/tests/utils.spec.ts
+++ b/packages/plugins/generic-auth/tests/utils.spec.ts
@@ -111,7 +111,7 @@ it('removes fragment spreads that reference empty fragments with leftover empty 
      }
    }
 
-   fragment A on Admin "
+   fragment A on Admin"
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
@@ -200,7 +200,7 @@ it('recursively removes fragments referencing other fragments that are empty', (
      ...B
    }
 
-   fragment B on User "
+   fragment B on User"
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);
@@ -262,7 +262,7 @@ it('removes all fields referencing empty fragments', () => {
      }
    }
 
-   fragment A on Admin "
+   fragment A on Admin"
   `);
 
   const sanitized = removeEmptyOrUnusedNodes(document);


### PR DESCRIPTION
Causing issues with https://github.com/graphql-hive/gateway/pull/1629 due to malformed queries for query planning.

The generic-auth plugin leaves document nodes broken after validation and redaction of unauthenticated fields. Given a schema:

```graphql
type Query {
  public: String
  person: Person
}
interface Person {
  name: String
}
type Admin implements Person @authenticated {
  name: String
  email: String
}
```
the following user query:
```graphql
{
  public
  person {
    name
    ... on Admin {
      email
    }
  }
}
```
will be incorrectly redacted to:
```diff
{
  public
  person {
    name
-   ... on Admin
  }
}
```
secondly, the following query:
```graphql
{
  public
  person {
    ... on Admin {
      email
    }
  }
}
```
will be incorrectly redacted to:
```diff
{
  public
- person {
-   ... on Admin
- }
}
```
finally, the following query:
```graphql
{
  public
  person {
    ...A
  }
}
fragment A on Admin {
  email
}
```
will be incorrectly redacted to:
```diff
query {
  public
- person {
-   ...A
- }
}
- fragment A on Admin 
```

### TODO

While working on the task, I noticed more issues with the generic-plugin itself (was broken without the fixes too) see skipped tests in `use-generic-auth.spec.ts`.