### PR TITLE
feat: add option to ignore default resolvers in opentelemetry

### DIFF
--- a/.changeset/frank-pigs-teach.md
+++ b/.changeset/frank-pigs-teach.md
@@ -1,0 +1,6 @@
+---
+'@envelop/on-resolve': minor
+'@envelop/opentelemetry': minor
+---
+
+Add option to ignore default resolvers in opentelemetry instrumentation

--- a/.changeset/frank-pigs-teach.md
+++ b/.changeset/frank-pigs-teach.md
@@ -4,3 +4,26 @@
 ---
 
 Add option to ignore default resolvers in opentelemetry instrumentation
+
+To reduce telemetry data volume and noise in traces, it is recommended to ignore resolvers with the
+default implementation since they probably doesn't do anything worth tracking.
+
+## Usage
+
+```ts
+import { execute, parse, specifiedRules, subscribe, validate } from 'graphql'
+import { envelop, useEngine } from '@envelop/core'
+import { useOpenTelemetry } from '@envelop/opentelemetry'
+
+const getEnveloped = envelop({
+  plugins: [
+    useEngine({ parse, validate, specifiedRules, execute, subscribe }),
+    // ... other plugins ...
+
+    useOpenTelemetry({
+      resolvers: true,
+      defaultResolvers: false // explicitly disable default resolvers tracing. Defaults to `true`
+    })
+  ]
+})
+```

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -40,6 +40,13 @@ export type UseOnResolveOptions = {
    * @default true
    */
   skipIntrospection?: boolean;
+
+  /**
+   * Skip executing the `onResolve` hook on fields with default resolvers.
+   *
+   * @default false
+   */
+  skipDefaultResolvers?: boolean;
 };
 
 /**
@@ -49,7 +56,7 @@ export type UseOnResolveOptions = {
  */
 export function useOnResolve<PluginContext extends Record<string, any> = {}>(
   onResolve: OnResolve<PluginContext>,
-  opts: UseOnResolveOptions = { skipIntrospection: true },
+  opts: UseOnResolveOptions = { skipIntrospection: true, skipDefaultResolvers: false },
 ): Plugin<PluginContext> {
   const hasWrappedResolveSymbol = Symbol('hasWrappedResolve');
   return {
@@ -61,6 +68,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
         if ((!opts.skipIntrospection || !isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
             if ((field as { [hasWrappedResolveSymbol]?: true })[hasWrappedResolveSymbol]) continue;
+            if (opts.skipDefaultResolvers && !field.resolve) continue;
 
             let resolver = (field.resolve || defaultFieldResolver) as Resolver<PluginContext>;
 

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -70,7 +70,9 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
             if ((field as { [hasWrappedResolveSymbol]?: true })[hasWrappedResolveSymbol]) continue;
             if (
               opts.skipDefaultResolvers &&
-              (!field.resolve || field.resolve?.name === 'defaultFieldResolver')
+              (!field.resolve ||
+                field.resolve?.name === 'defaultFieldResolver' ||
+                field.resolve?.name === 'defaultMergedResolver')
             ) {
               continue;
             }

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -70,7 +70,7 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
             if ((field as { [hasWrappedResolveSymbol]?: true })[hasWrappedResolveSymbol]) continue;
             if (
               opts.skipDefaultResolvers &&
-              (!field.resolve || field.resolve === defaultFieldResolver)
+              (!field.resolve || field.resolve?.name === 'defaultFieldResolver')
             ) {
               continue;
             }

--- a/packages/plugins/on-resolve/src/index.ts
+++ b/packages/plugins/on-resolve/src/index.ts
@@ -68,7 +68,12 @@ export function useOnResolve<PluginContext extends Record<string, any> = {}>(
         if ((!opts.skipIntrospection || !isIntrospectionType(type)) && isObjectType(type)) {
           for (const field of Object.values(type.getFields())) {
             if ((field as { [hasWrappedResolveSymbol]?: true })[hasWrappedResolveSymbol]) continue;
-            if (opts.skipDefaultResolvers && !field.resolve) continue;
+            if (
+              opts.skipDefaultResolvers &&
+              (!field.resolve || field.resolve === defaultFieldResolver)
+            ) {
+              continue;
+            }
 
             let resolver = (field.resolve || defaultFieldResolver) as Resolver<PluginContext>;
 

--- a/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
+++ b/packages/plugins/on-resolve/test/use-on-resolve.spec.ts
@@ -8,12 +8,20 @@ describe('useOnResolve', () => {
       type Query {
         value1: String!
         value2: String!
+        obj: Obj!
+      }
+
+      type Obj {
+        field1: String!
       }
     `,
     resolvers: {
       Query: {
         value1: () => 'value1',
         value2: () => 'value2',
+        obj: () => ({
+          field1: 'field1',
+        }),
       },
     },
   });
@@ -83,6 +91,47 @@ describe('useOnResolve', () => {
 
     expect(onResolveFn).toHaveBeenCalledTimes(0);
     expect(onResolveDoneFn).toHaveBeenCalledTimes(0);
+  });
+
+  it('should invoke the callback for default resolvers when not skipping', async () => {
+    const onResolveDoneFn = jest.fn();
+    const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
+    const testkit = createTestkit(
+      [useOnResolve(onResolveFn, { skipDefaultResolvers: false })],
+      schema,
+    );
+
+    await testkit.execute('{ obj { field1 } }');
+
+    expect(onResolveFn).toHaveBeenCalledTimes(2);
+    expect(onResolveDoneFn).toHaveBeenCalledTimes(2);
+
+    let i = 0;
+    for (const field of ['obj', 'field1']) {
+      expect(onResolveFn.mock.calls[i][0].context).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].root).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].args).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].info).toBeDefined();
+      expect(onResolveFn.mock.calls[i][0].info.fieldName).toBe(field);
+      expect(onResolveFn.mock.calls[i][0].resolver).toBeInstanceOf(Function);
+      expect(onResolveFn.mock.calls[i][0].replaceResolver).toBeInstanceOf(Function);
+
+      i++;
+    }
+  });
+
+  it('should not invoke the callback for default resolvers when skipping', async () => {
+    const onResolveDoneFn = jest.fn();
+    const onResolveFn = jest.fn((_opts: OnResolveOptions) => onResolveDoneFn);
+    const testkit = createTestkit(
+      [useOnResolve(onResolveFn, { skipDefaultResolvers: true })],
+      schema,
+    );
+
+    await testkit.execute('{ obj { field1 } }');
+
+    expect(onResolveFn).toHaveBeenCalledTimes(1);
+    expect(onResolveDoneFn).toHaveBeenCalledTimes(1);
   });
 
   it('should replace the result using the after hook', async () => {

--- a/packages/plugins/opentelemetry/src/index.ts
+++ b/packages/plugins/opentelemetry/src/index.ts
@@ -124,7 +124,7 @@ export const useOpenTelemetry = (
 
               return () => {};
             },
-            { skipDefaultResolvers: (options.defaultResolvers ?? true) === false },
+            { skipDefaultResolvers: options.defaultResolvers === false },
           ),
         );
       }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

 - Adds an option to `useOnResolve` to skip resolvers that use the default resolver.
 - Adds a corresponding option to `useOpentelemetry` to skip tracing fields that use the default resolver. This is equivalent to the `ignoreTrivialResolveSpans` option in [@opentelemetry/instrumentation-graphql](https://www.npmjs.com/package/@opentelemetry/instrumentation-graphql)

Fixes https://github.com/graphql-hive/envelop/issues/2132

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Added unit tests for both the enabled and disabled state of this flag.

**Test Environment**:

- OS: Mac 26
- NodeJS: 22.4.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Unfortunately I did not realize @Akryum had proposed part of the same change in https://github.com/graphql-hive/envelop/pull/2133 until I started to write this PR. This PR includes tests and the corresponding change to `useOpentelemetry`, so hopefully it can be merged.
