### PR TITLE
fix(with-state): always add state to payload if plain object

### DIFF
--- a/.changeset/curly-banks-stand.md
+++ b/.changeset/curly-banks-stand.md
@@ -1,0 +1,5 @@
+---
+'@envelop/core': patch
+---
+
+Fixes `onFetch` hook not having the `state` attribute in payload on non-upstream `fetch` calls.

--- a/packages/core/src/plugin-with-state.ts
+++ b/packages/core/src/plugin-with-state.ts
@@ -1,5 +1,21 @@
 import { MaybePromise } from '@whatwg-node/promise-helpers';
 
+/**
+ * A function allowing to add a `state` to the payload (first object parameter of any function)
+ */
+export function withState<
+  P extends { instrumentation?: GenericInstrumentation },
+  HttpState = object,
+  GraphqlState = object,
+  SubExecState = object,
+>(
+  pluginFactory: (
+    getState: <SP extends {}>(
+      payload: SP,
+    ) => PayloadWithState<SP, HttpState, GraphqlState, SubExecState>['state'],
+  ) => PluginWithState<P, HttpState, GraphqlState, SubExecState>,
+): P;
+// Secondary signature with simpler generics when you have the same state in all layers
 export function withState<P extends { instrumentation?: GenericInstrumentation }, State = object>(
   pluginFactory: (
     getState: <SP extends {}>(payload: SP) => PayloadWithState<SP, State, State, State>['state'],
@@ -75,7 +91,7 @@ export function withState<
       } else {
         result[hookName] = {
           [hook.name](payload: any, ...args: any[]) {
-            if (payload && (payload.request || payload.context || payload.executionRequest)) {
+            if (payload && Object.getPrototypeOf(payload) === Object.prototype) {
               return hook(
                 {
                   ...payload,


### PR DESCRIPTION
This PR fixes the condition that was introduced to avoid touching non-hooks methods of a plugin.

It was relying on the fact that at least one of `request`, `context` or `executionRequest` should be present to be concidered as an actual hook.

But that's not always true, `onFetch` can in some cases have a payload without any of those fields.

So this PR instead adds the `state` to the first paramter as long as it is a plain object.