### PR TITLE
graphql-modules plugin: Bind context to async execution avoiding race-conditions

### DIFF
--- a/.changeset/polite-baths-stop.md
+++ b/.changeset/polite-baths-stop.md
@@ -1,0 +1,5 @@
+---
+'@envelop/graphql-modules': patch
+---
+
+Bind context to async execution avoiding race-conditions

--- a/packages/plugins/graphql-modules/src/index.ts
+++ b/packages/plugins/graphql-modules/src/index.ts
@@ -7,10 +7,18 @@ export const useGraphQLModules = (app: Application): Plugin => {
       setSchema(app.schema);
     },
     onExecute({ setExecuteFn, executeFn }) {
-      setExecuteFn(app.createExecution({ execute: executeFn }));
+      setExecuteFn(
+        app.createExecution({
+          execute: executeFn,
+        }),
+      );
     },
     onSubscribe({ setSubscribeFn, subscribeFn }) {
-      setSubscribeFn(app.createSubscription({ subscribe: subscribeFn }));
+      setSubscribeFn(
+        app.createSubscription({
+          subscribe: subscribeFn,
+        }),
+      );
     },
   };
 };

--- a/packages/plugins/graphql-modules/src/index.ts
+++ b/packages/plugins/graphql-modules/src/index.ts
@@ -1,51 +1,16 @@
 import type { Application } from 'graphql-modules';
-import type { Plugin, TypedExecutionArgs } from '@envelop/core';
-
-const graphqlModulesControllerSymbol = Symbol('GRAPHQL_MODULES');
-
-function destroy(context: TypedExecutionArgs<any>) {
-  if (context.contextValue?.[graphqlModulesControllerSymbol]) {
-    context.contextValue[graphqlModulesControllerSymbol].destroy();
-    context.contextValue[graphqlModulesControllerSymbol] = null;
-  }
-}
+import type { Plugin } from '@envelop/core';
 
 export const useGraphQLModules = (app: Application): Plugin => {
   return {
     onPluginInit({ setSchema }) {
       setSchema(app.schema);
     },
-    onContextBuilding({ extendContext, context }) {
-      const controller = app.createOperationController({
-        context,
-        autoDestroy: false,
-      });
-
-      extendContext({
-        ...controller.context,
-        [graphqlModulesControllerSymbol]: controller,
-      });
+    onExecute({ setExecuteFn, executeFn }) {
+      setExecuteFn(app.createExecution({ execute: executeFn }));
     },
-    onExecute({ args }) {
-      return {
-        onExecuteDone() {
-          destroy(args);
-        },
-      };
-    },
-    onSubscribe({ args }) {
-      return {
-        onSubscribeResult({ args }) {
-          return {
-            onEnd() {
-              destroy(args);
-            },
-          };
-        },
-        onSubscribeError() {
-          destroy(args);
-        },
-      };
+    onSubscribe({ setSubscribeFn, subscribeFn }) {
+      setSubscribeFn(app.createSubscription({ subscribe: subscribeFn }));
     },
   };
 };

--- a/packages/plugins/graphql-modules/test/use-graphql-modules.spec.ts
+++ b/packages/plugins/graphql-modules/test/use-graphql-modules.spec.ts
@@ -101,6 +101,8 @@ describe('useGraphQLModules', () => {
     expect(isDestroyed).toEqual(true);
   });
 
+  // TODO: check how well it works with graphql-modules when integrating other envelop plugins
+
   test("merging singleton provider context with envelop's context", async () => {
     @Injectable({ scope: Scope.Singleton })
     class IdentifierProvider {

--- a/scripts/match-graphql.js
+++ b/scripts/match-graphql.js
@@ -1,4 +1,4 @@
-const { writeFileSync } = require('fs');
+const { writeFileSync, readFileSync } = require('fs');
 const { resolve } = require('path');
 const { argv, cwd } = require('process');
 
@@ -19,3 +19,18 @@ pkg.pnpm.overrides.graphql = npmVersion;
 pkg.devDependencies.graphql = npmVersion;
 
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2), 'utf8');
+
+// fix the graphql-modules plugin because the modules expectes a different signature on the execute
+// and this would be a specific issue to graphql-modules and not envelop since we're using a peer graphql
+if (version.startsWith('15.')) {
+  console.log('Patching graphql-modules plugin for GraphQL v15...');
+  const modulesPluginPath = resolve(cwd(), './packages/plugins/graphql-modules/src/index.ts');
+
+  const modulesPluginSource = readFileSync(modulesPluginPath, 'utf8');
+  const lines = modulesPluginSource.split('\n');
+
+  lines.splice(11, 0, '// @ts-expect-error only for graphql v15, revert when upgrading to v16');
+  lines.splice(19, 0, '// @ts-expect-error only for graphql v15, revert when upgrading to v16');
+
+  writeFileSync(modulesPluginPath, lines.join('\n'), 'utf8');
+}


### PR DESCRIPTION
Even though `graphql-modules` is a peer dependency of the `@envelop/graphql-modules` plugin, the fix in https://github.com/graphql-hive/graphql-modules/pull/2521 was not inherited due to the nature of how envelop performed the execution - it did not use modules' executor, it used its own, therfore circumventing the synchronisation adaptations for concurrent access to the context.

This fix changes to using modules' executor and therefore inheriting all of its execution logic.