### PR TITLE
fix: use context extension context for the error handler

### DIFF
--- a/.changeset/soft-baboons-report.md
+++ b/.changeset/soft-baboons-report.md
@@ -1,0 +1,6 @@
+---
+'@envelop/core': patch
+---
+
+Pass latest mergable context to `useErrorHandler` hook when the error originates from a context
+extension.

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -63,8 +63,8 @@ export const useErrorHandler = <ContextType extends Record<string, any>>(
         }
       };
     },
-    onPluginInit(context) {
-      context.registerContextErrorHandler(({ error, context }) => {
+    onPluginInit({ registerContextErrorHandler }) {
+      registerContextErrorHandler(({ error, context }) => {
         if (isGraphQLError(error)) {
           errorHandler({ errors: [error], context, phase: 'context' });
         } else {

--- a/packages/core/src/plugins/use-error-handler.ts
+++ b/packages/core/src/plugins/use-error-handler.ts
@@ -64,7 +64,7 @@ export const useErrorHandler = <ContextType extends Record<string, any>>(
       };
     },
     onPluginInit(context) {
-      context.registerContextErrorHandler(({ error }) => {
+      context.registerContextErrorHandler(({ error, context }) => {
         if (isGraphQLError(error)) {
           errorHandler({ errors: [error], context, phase: 'context' });
         } else {


### PR DESCRIPTION
## Description

Some properties that are in my context are not accessible in the error handler if an error is raised within a further context building hook.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Unit test
